### PR TITLE
Adds keyboard emulation functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Apiary NFC Reader
 
-Script for piping GTID / Prox # from BuzzCards to Apiary through a web socket.
-
+Script for piping GTID from BuzzCards to Apiary through a web socket or keyboard emulation.
 
 ## Package requirements
 
@@ -22,10 +21,24 @@ pip install -r requirements.txt
 
 ## Running the script
 
-To run the script, issue the following command;
+The script supports running either as a WebSocket server or a keyboard emulator.
+The mode is determined with a parameter (`-s` for WebSocket, `-k` for keyboard).
 
+
+###Keyboard Mode:
 ```
-python card_reader_server.py
+python card_reader_server.py -k
+```
+
+On **macOS**, one of the following must be true:
+
+- The process must run as root.
+- The application must be white listed in _System Preferences_ -> _Security_ -> _Privacy_ -> _Accessibility_. 
+Depending on the version of macOS, your terminal emulator and/or IDE may also need to be whitelisted.
+
+###WebSocket Mode:
+```
+python card_reader_server.py -s
 ```
 
 ## Supervisor configuration
@@ -35,7 +48,7 @@ To run the script using Supervisor, use the following configuration:
 ```
 [program:apiary-nfc-reader]
 directory=<path to where you cloned it>
-command=python card_reader_server.py
+command=python card_reader_server.py <-k or -s>
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The script supports running either as a WebSocket server or a keyboard emulator.
 The mode is determined with a parameter (`-s` for WebSocket, `-k` for keyboard).
 
 
-###Keyboard Mode:
+### Keyboard Mode:
 ```
 python card_reader_server.py -k
 ```
@@ -36,7 +36,7 @@ On **macOS**, one of the following must be true:
 - The application must be white listed in _System Preferences_ -> _Security_ -> _Privacy_ -> _Accessibility_. 
 Depending on the version of macOS, your terminal emulator and/or IDE may also need to be whitelisted.
 
-###WebSocket Mode:
+### WebSocket Mode:
 ```
 python card_reader_server.py -s
 ```

--- a/card_reader_server.py
+++ b/card_reader_server.py
@@ -65,7 +65,7 @@ class PrintObserver(CardObserver):
             if keyboard_enabled:
                 keyboard.type(str(file_data_byte[0]))
                 keyboard.press(Key.enter)
-
+                keyboard.release(Key.enter)
 
 class WebSocket(WebSocketServerProtocol):
     connections = list()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pyscard
 Twisted
 autobahn
+argparse
+pynput


### PR DESCRIPTION
Adds keyboard emulation functionality for applications where web sockets aren't compatible, or reliable enough (*cough* kiosk *cough*).

**Breaking Change** One of `-k` or `-s` _must_ be specified when running the script to determine keyboard or web socket mode. README has been updated to reflect this. Setting keyboard as default was suggested, but that made argparse complicated so a parameter of one or the other is required for now.